### PR TITLE
Implement first version of hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,14 @@
 
 ## Added
 
-## Fixed
+- Added `after-build` hooks on the factory and trait level
+- Added `lambdaisland.factory/update-result` for use in hooks
 
 ## Changed
 
+- Breaking: traits now need an extra wrapping map, similar to the options map, with `:with` and optionally `:after-build`
+
 # 0.3.27-alpha (2022-05-04 / 8ab563a)
-
-## Added
-
-## Fixed
 
 ## Changed
 

--- a/src/lambdaisland/facai.cljc
+++ b/src/lambdaisland/facai.cljc
@@ -87,3 +87,8 @@
 
 (defn sel1 [result path]
   (first (sel result path)))
+
+(defn update-result
+  "Update the result value in a context map, useful in hooks."
+  [ctx f & args]
+  (apply update ctx :facai.result/value f args))


### PR DESCRIPTION
Implements first version of hooks as discussed in #1 . We support an `:after-build` on the factory and on the trait

```clj
(f/defactory multiple-hooks
  {:bar 1}

  :traits
  {:some-trait
   {:with {:bar 2}
    :after-build
    (fn [ctx]
      (f/update-result ctx update :bar inc))}}

  :after-build
  (fn [ctx]
    (f/update-result ctx update :bar #(- %))))
```