### PR TITLE
[BREAKING] Automatically defer when invoking a factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ looks like.
    :user/handle "lilli42"
    :user/email  #(str "lilli" (rand-int 100) "@example.com")})
 
-(user)
+(f/build-val user)
 ;; => #:user{:name "Lilliam Predovic",
 ;;           :handle "lilli42",
 ;;           :email "lilli92@example.com"}
@@ -133,13 +133,12 @@ looks like.
    :article/status :draft}
 
   :traits
-  {:with
-   {:published {:article/status "published"}
-    :unpublished {:article/status "unpublished"}
-    :in-the-future {:article/published-at #(fh/days-from-now 2)}
-    :in-the-past {:article/published-at #(fh/days-ago 2)}}})
+  {:published {:with {:article/status "published"}}
+   :unpublished {:with {:article/status "unpublished"}}
+   :in-the-future {:with {:article/published-at #(fh/days-from-now 2)}}
+   :in-the-past {:with {:article/published-at #(fh/days-ago 2)}}})
 
-(article {:traits [:published :in-the-future]})
+(f/build-val article {:traits [:published :in-the-future]})
 ;; => #:article{:title "7 Tip-top Things To Try",
 ;;              :status "published",
 ;;              :published-at
@@ -153,7 +152,7 @@ looks like.
    :article/submitter user
    :article/author (user {:with {:user/roles #{"author"}}})})
 
-(article)
+(f/build-val article)
 ;; => #:article{:title "7 Tip-top Things To Try",
 ;;              :submitter
 ;;              #:user{:name "Mr. Reinaldo Hartmann",
@@ -170,7 +169,7 @@ looks like.
 ;; will only get expanded when building the `article`, so you get a different
 ;; username each time.
 
-(article)
+(f/build-val article)
 ;; => #:article{:title "7 Tip-top Things To Try",
 ;;              :submitter
 ;;              #:user{:name "Hobert Fadel",
@@ -190,7 +189,7 @@ looks like.
   :inherit article
   {:post/uri-slug "/post"})
 
-(blog-post)
+(f/build-val blog-post)
 ;; => {:article/title "7 Tip-top Things To Try",
 ;;     :article/submitter
 ;;     #:user{:name "Rima Wintheiser",
@@ -403,9 +402,9 @@ which is a shorthand for `(update ctx :facai.result/value ...)`
      (fn [{:as res :keys [product quantity]}]
        (assoc res :total (* (:price product) quantity))))))
 
-(product-line-item);; => {:product {:sku "123", :price 12.99}, :quantity 1, :total 12.99}
-(product-line-item {:with {:quantity 2}});; => {:product {:sku "123", :price 12.99}, :quantity 2, :total 25.98}
-(product-line-item {:rules {:price 69 :quantity 2}});; => {:product {:sku "123", :price 69}, :quantity 2, :total 138}
+(f/build-val product-line-item);; => {:product {:sku "123", :price 12.99}, :quantity 1, :total 12.99}
+(f/build-val product-line-item {:with {:quantity 2}});; => {:product {:sku "123", :price 12.99}, :quantity 2, :total 25.98}
+(f/build-val product-line-item {:rules {:price 69 :quantity 2}});; => {:product {:sku "123", :price 69}, :quantity 2, :total 138}
 ```
 
 Notice how the result always has the right total price.

--- a/README.md
+++ b/README.md
@@ -78,18 +78,16 @@ looks like.
    :user/handle "lilli42"
    :user/email  "lilli42@example.com"})
 
-;; We can generate data from this template by calling the factory as a function,
-;; which is an alias for calling `f/build-val`
+;; We can generate data from this template by calling `f/build-val`
 
-(user) ; or (f/build-val user)
+(f/build-val user)
 ;; => #:user{:name "Lilliam Predovic",
 ;;           :handle "lilli42",
 ;;           :email "lilli42@example.com"}
 
-;; It can take a few options, use `:with` to override or supply additional
-;; values.
+;; To override additional values you can pass a map to the factory:
 
-(user {:with {:user/name "Mellissa Schimmel"}})
+(f/build-val (user {:user/name "Mellissa Schimmel"}))
 ;; => #:user{:name "Mellissa Schimmel",
 ;;           :handle "lilli42",
 ;;           :email "lilli42@example.com"}
@@ -205,6 +203,50 @@ looks like.
 ;;            :roles #{"author"}},
 ;;     :post/uri-slug "/post"}
 ```
+
+## Deferred factory generation
+
+When calling a factory as a function, rather than actually generating data, we
+simply return a value that keeps track of the factory you called, and the
+options you passed. Actual instantiation only happens when you call
+`f/build-val`.
+
+This provides a concise way to specify overrides, either when creating
+factories, or when building values.
+
+```clj
+(f/defactory article
+ {:article/submitter (user {:user/name "Mr. submit"})})
+ 
+;; or
+
+(f/build-val article {:with {:article/submitter {:user/name "Mr. submit"}}})
+
+;; or
+
+(f/build-val (article {:article/submitter {:user/name "Mr. submit"}}))
+```
+
+The syntax works as follows. `f/build-val` takes two arguments, a factory or
+template, and a map of options: `:with`, `:rules`, `:traits`.
+
+Calling a factory with *keyword arguments* (key value pairs) is equivalent to
+passing these options in to `f/build-val`.
+
+When passing a single map instead of keyword args this is equivalent to using
+`:with`.
+
+```clj
+(f/build-val user {:with {:user/name "jill"}})
+;; equals
+(user :with {:user/name "jill"}
+;; equals
+(user {:user/name "jill"}
+```
+
+This provides a concise syntax for the most common case: overriding values,
+while still allowing us to distinguish explicit options like `:rules` and
+`:traits`.
 
 ## Paths, Selectors, Rules, and Unification
 

--- a/src/lambdaisland/facai.cljc
+++ b/src/lambdaisland/facai.cljc
@@ -16,12 +16,29 @@
 (defrecord Factory []
   #?@(:clj
       (clojure.lang.IFn
-       (invoke [this] (build-val this nil))
-       (invoke [this opts] (build-val this opts)))
+       (applyTo [this xs] (clojure.lang.AFn/applyToHelper this xs))
+       (invoke [this] this)
+       (invoke [this opts] (fk/defer this {:with opts}))
+       (invoke [this k v] (fk/defer this {k v}))
+       (invoke [this ka va kb vb] (fk/defer this {ka va kb vb}))
+       (invoke [this ka va kb vb kc vc] (fk/defer this {ka va kb vb kc vc}))
+       (invoke [this ka va kb vb kc vc kd vd] (fk/defer this {ka va kb vb kc vc kd vd}))
+       (invoke [this ka va kb vb kc vc kd vd ke ve] (fk/defer this {ka va kb vb kc vc kd vd ke ve}))
+       (invoke [this ka va kb vb kc vc kd vd ke ve kf vf] (fk/defer this {ka va kb vb kc vc kd vd ke ve kf vf}))
+       (invoke [this ka va kb vb kc vc kd vd ke ve kf vf kg vg] (fk/defer this {ka va kb vb kc vc kd vd ke ve kf vf kg vg}))
+       (invoke [this ka va kb vb kc vc kd vd ke ve kf vf kg vg kh vh] (fk/defer this {ka va kb vb kc vc kd vd ke ve kf vf kg vg kh vh})))
       :cljs
       (cljs.core/IFn
-       (-invoke [this] (build-val this nil))
-       (-invoke [this opts] (build-val this opts)))))
+       (-invoke [this] this)
+       (-invoke [this opts] (fk/defer this {:with opts}))
+       (-invoke [this k v] (fk/defer this {k v}))
+       (-invoke [this ka va kb vb] (fk/defer this {ka va kb vb}))
+       (-invoke [this ka va kb vb kc vc] (fk/defer this {ka va kb vb kc vc}))
+       (-invoke [this ka va kb vb kc vc kd vd] (fk/defer this {ka va kb vb kc vc kd vd}))
+       (-invoke [this ka va kb vb kc vc kd vd ke ve] (fk/defer this {ka va kb vb kc vc kd vd ke ve}))
+       (-invoke [this ka va kb vb kc vc kd vd ke ve kf vf] (fk/defer this {ka va kb vb kc vc kd vd ke ve kf vf}))
+       (-invoke [this ka va kb vb kc vc kd vd ke ve kf vf kg vg] (fk/defer this {ka va kb vb kc vc kd vd ke ve kf vf kg vg}))
+       (-invoke [this ka va kb vb kc vc kd vd ke ve kf vf kg vg kh vh] (fk/defer this {ka va kb vb kc vc kd vd ke ve kf vf kg vg kh vh})))))
 
 (defn factory
   "Create a factory instance, these are just maps with a `(comp :type meta)` of

--- a/src/lambdaisland/facai/kernel.cljc
+++ b/src/lambdaisland/facai/kernel.cljc
@@ -22,7 +22,9 @@
     (var? thunk)
     @thunk
     (factory? thunk)
-    thunk
+    (if-let [resolve (:facai.factory/resolve thunk)]
+      (resolve)
+      thunk)
     :else
     (thunk)))
 


### PR DESCRIPTION
This is a breaking change, we are still in alpha after all, and I think this is worth it. I'll do my best to explain my reasoning.

Up to now invoking a factory (calling it as a function) would be equivalent to `build-val`, that is: it returns an instantiated value based on the factory template, and any options you pass in like `:with`, `:traits`, `:rules`.

But, if you called a factory inside another `defactory`, we would _defer_ the build process, we simply captured that this is the factory and these are the options, and when the actual build happens we apply them.

```clj
(f/defactory foo
  {:name "Arne"})

(foo) ;;=> {:name "Arne"}

(f/defactory bar
  {:foo (foo {:with {:name "Ben"}})})

(:facai.factory/template bar)
;;=>
{:foo (->DeferredBuild foo {:with {:name "Ben"}})}
```

This way you can then do things like. In other words we apply late binding, so that you can still override and influence things when building the top-level thing. It's also vital when working with the database layers, only entities that get created as part of the process get inserted. If it's already instantiated to a plain clojure value then the db layer doesn't know what to do with that.

```clj
(f/build-val bar {:rules {[foo :name] "Paul"})
```

The problem that this creates is that you can't do this

```clj
(def foo-with-ben
  (foo {:with {:name "Ben"}}))

(f/defactory bar
  {:foo foo-with-ben})
;; or during building
(f/build-val bar {:with {:foo foo-with-ben}})
```

So even though this is a straightforward refactoring of the earlier code, it breaks. I worked around this by introducing some explicit helpers to create these deferred-build instances, but I don't really want people to have to think about when they need to use them.

The thing is also that when using Facai I expect people to mostly be using it via a database layer, so you're always calling some kind of `create!` function explicitly, why not repurpose the direct-invocation API to provide a cleaner syntax, by always returning a deferred?

We can also use this to fix another issue, overriding plain values is extremely common, and always having to do `{:with ...}`  kind of sucks. So the idea is that if you pass a map, we treat these as overrides. If you use keyword args, we treat them as options.

```clj
(foo {:name "Arne"}) ;; overrides, :with is implicit
(foo :with {:name "Arne"} :traits ["authenticated"]) ;; options
```

There might be another (and somewhat bigger) breaking change that falls out of this, in that we might want to apply this same syntax to `build`/`build-val`/`create` etc, for symmetry

```clj
(f/build-val foo {:name "Arne"})
(f/build-val foo :traits ["cool])
```

- [ ] CHANGELOG
- [ ] review docs